### PR TITLE
Add VEIKK A50 device ID

### DIFF
--- a/veikk.c
+++ b/veikk.c
@@ -31,6 +31,7 @@ struct veikk {
 
 static const struct hid_device_id id_table[] = {
   { HID_USB_DEVICE(0x2feb, 0x0001) },
+  { HID_USB_DEVICE(0x2feb, 0x0003) },
   { }
 };
 MODULE_DEVICE_TABLE(hid, id_table);


### PR DESCRIPTION
Hi!

First of all, thanks a lot for your amazing work! I've been searching for quite a while before I found your driver, and then there's suddenly not just working code, but also a very detailed blog post describing it!

I don't own the s640, but have a VEIKK A50 instead. Fortunately, it turned out that simply adding the device ID was enough to get the pen to work, including pressure sensitivity. I did not look into getting the buttons or touchpad on the A50 working yet. I might look into those later, but I think this tiny change may already be helpful to others.